### PR TITLE
Fixed triangulations to use all ring points

### DIFF
--- a/Source/Include/Ag/Geometry/DCEL.hpp
+++ b/Source/Include/Ag/Geometry/DCEL.hpp
@@ -512,6 +512,8 @@ public:
     static constexpr uint32_t IsHole = 0x10;
     static constexpr uint32_t HasChildren = 0x20;
     static constexpr uint32_t IsSurrounding = 0x40;
+    static constexpr uint32_t HasIntermediateHorzNodes = 0x80;
+    static constexpr uint32_t HasIntermediateVertNodes = 0x100;
 
     // Construction/Destruction
     Ring(ID ringID, HalfEdgePtr firstHalfEdge,


### PR DESCRIPTION
Triangulations of partitioned polygons which contained horizontal or vertical lines with intermediate points might not use those intermediate points - a problem if we are trying to smooth shade a rectangle with gradient stops.